### PR TITLE
[RFC] Make axes return IdentityRange

### DIFF
--- a/src/IdentityRanges.jl
+++ b/src/IdentityRanges.jl
@@ -29,7 +29,7 @@ IdentityRange(3:5)
 julia> v2 = view(a, idr);
 
 julia> axes(v2, 1)
-3:5
+IdentityRange(3:5)
 ```
 """
 struct IdentityRange{T<:Integer} <: AbstractUnitRange{T}
@@ -39,8 +39,8 @@ struct IdentityRange{T<:Integer} <: AbstractUnitRange{T}
 end
 IdentityRange(start::T, stop::T) where {T<:Integer} = IdentityRange{T}(start, stop)
 
-Base.axes(r::IdentityRange) = (r.start:r.stop,)
-Base.unsafe_indices(r::IdentityRange) = (r.start:r.stop,)
+Base.axes(r::IdentityRange) = (r,)
+Base.unsafe_indices(r::IdentityRange) = (r,)
 
 _length(r::IdentityRange{T}) where {T} = max(zero(T), convert(T, r.stop-r.start+1))
 Base.length(r::IdentityRange) = _length(r)

--- a/src/IdentityRanges.jl
+++ b/src/IdentityRanges.jl
@@ -99,7 +99,7 @@ end
 # Unary operation
 
 function Base.:-(r::IdentityRange)
-    indsr = axes(r, 1)
+    indsr = r.start:r.stop
     OffsetArray(-indsr, indsr)
 end
 
@@ -108,31 +108,31 @@ end
 for T in (Real, Number)
     @eval begin
         function Broadcast.broadcasted(::DefaultArrayStyle{1}, ::typeof(+), r::IdentityRange, x::$T)
-            indsr = axes(r, 1)
+            indsr = r.start:r.stop
             OffsetArray(indsr.+x, indsr)
         end
         Broadcast.broadcasted(::DefaultArrayStyle{1}, ::typeof(+),  x::$T, r::IdentityRange) = r .+ x
         function Broadcast.broadcasted(::DefaultArrayStyle{1}, ::typeof(-), r::IdentityRange, x::$T)
-            indsr = axes(r, 1)
+            indsr = r.start:r.stop
             OffsetArray(indsr.-x, indsr)
         end
         function Broadcast.broadcasted(::DefaultArrayStyle{1}, ::typeof(-), x::$T, r::IdentityRange)
-            indsr = axes(r, 1)
+            indsr = r.start:r.stop
             OffsetArray(x.-indsr, indsr)
         end
     end
 end
 function Base.:*(r::IdentityRange, x::Number)
-    indsr = axes(r, 1)
+    indsr = r.start:r.stop
     OffsetArray(indsr.*x, indsr)
 end
 Base.:*(x::Number, r::IdentityRange) = r*x
 function Base.:/(r::IdentityRange, x::Number)
-    indsr = axes(r, 1)
+    indsr = r.start:r.stop
     OffsetArray(indsr./x, indsr)
 end
 function Base.:\(x::Number, r::IdentityRange)
-    indsr = axes(r, 1)
+    indsr = r.start:r.stop
     OffsetArray(x .\ indsr, indsr)
 end
 Broadcast.broadcasted(::DefaultArrayStyle{1}, ::typeof(*), r::IdentityRange, x::Number) = r * x
@@ -143,7 +143,7 @@ Broadcast.broadcasted(::DefaultArrayStyle{1}, ::typeof(\), x::Number, r::Identit
 Base.collect(r::IdentityRange) = convert(Vector, first(r):last(r))
 Base.sortperm(r::IdentityRange) = r
 function Base.reverse(r::IdentityRange)
-    indsr = axes(r, 1)
+    indsr = r.start:r.stop
     OffsetArray(reverse(indsr), indsr)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,6 +107,14 @@ try
             @test axes(v) == (2:4, 3:4)
             @test v == OffsetArray(a[2:4, 3:4], 2:4, 3:4)
         end
+
+        @testset "findfirst, findlast, findall" begin
+            idr = IdentityRange(-2:2)
+            isneg = x -> x < 0
+            @test findfirst(isneg, idr) == -2
+            @test findlast(isneg, idr) == -1
+            @test findall(isneg, idr) == -2:-1
+        end
     end
 catch err
     if err.fail == 0 && err.error == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@ try
             @test !isempty(r)
             @test length(r) == 3
             @test size(r) == (3,)
-            @test axes(r) === (0:2,)
+            @test axes(r) === (r,)
             @test step(r) == 1
             @test first(r) == 0
             @test last(r) == 2
@@ -98,13 +98,13 @@ try
             a = rand(8)
             idr = IdentityRange(2:4)
             v = view(a, idr)
-            @test axes(v) == (2:4,)
+            @test axes(v) == (idr,)
             @test v == OffsetArray(a[2:4], 2:4)
 
             a = rand(5, 5)
             idr2 = IdentityRange(3:4)
             v = view(a, idr, idr2)
-            @test axes(v) == (2:4, 3:4)
+            @test axes(v) == (idr, idr2)
             @test v == OffsetArray(a[2:4, 3:4], 2:4, 3:4)
         end
 


### PR DESCRIPTION
Thanks @timholy for the guidance in #12! :)

The fix I've attempted is to make `axes` return back the `IdentityRange` to match the behavior of `Base.IdentityUnitRange` here: https://github.com/JuliaLang/julia/blob/2fc3dcdaecc0f77fee56400ee80752cc81c8dfb0/base/indices.jl#L382-L383

But doing so broke various operations that relied on the previous behavior, so I also modified those to not call axes. Is there a better way?

I also added some tests for `findfirst`, `findlast` and `findall` that currently error but work using this PR.

Fixes #12.